### PR TITLE
Refactor: 장바구니 컨트롤러를 RESTful 디자인 원칙에 맞게 리팩터링

### DIFF
--- a/src/main/java/com/bulkpurchase/domain/dto/cart/ItemAddRequest.java
+++ b/src/main/java/com/bulkpurchase/domain/dto/cart/ItemAddRequest.java
@@ -1,0 +1,11 @@
+package com.bulkpurchase.domain.dto.cart;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ItemAddRequest {
+    private Long productID;
+    private Integer quantity;
+}

--- a/src/main/java/com/bulkpurchase/domain/dto/cart/ItemDeleteRequest.java
+++ b/src/main/java/com/bulkpurchase/domain/dto/cart/ItemDeleteRequest.java
@@ -1,0 +1,15 @@
+package com.bulkpurchase.domain.dto.cart;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+public class ItemDeleteRequest {
+    private Long itemId;
+    private List<Long> itemIds;
+}

--- a/src/main/java/com/bulkpurchase/domain/dto/cart/ItemUpdateRequest.java
+++ b/src/main/java/com/bulkpurchase/domain/dto/cart/ItemUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.bulkpurchase.domain.dto.cart;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ItemUpdateRequest {
+    private Long itemId;
+    private Integer quantity;
+}

--- a/src/main/resources/static/js/cart.js
+++ b/src/main/resources/static/js/cart.js
@@ -108,20 +108,20 @@ $(document).ready(function () {
 
 function deleteCartItem(itemId) {
     $.ajax({
-        url: '/cart/delete',
-        type: 'POST',
-        data: {itemId: itemId},
+        url: '/cart/item',
+        type: 'DELETE',
+        contentType: 'application/json',
+        data: JSON.stringify({
+                itemId: itemId
+        }),
         success: function (response) {
-            // 삭제 성공 시 페이지에서 해당 항목 제거
-            // 예: $('#item-' + itemId).remove();
-            alert('상품이 삭제되었습니다.');
+            alert(response.message);
             $('#item-' + itemId).remove();
             updateCartSummary();
         },
         error: function (xhr, status, error) {
-            // 에러 처리, 서버로부터의 응답을 바탕으로 메시지를 표시
-            var errorMessage = xhr.responseJSON ? xhr.responseJSON.message : '삭제 중 오류가 발생했습니다.';
-            alert('삭제 중 오류가 발생했습니다.');
+            var errorMessage = JSON.parse(xhr.responseText).message;
+            alert(errorMessage);
         }
     });
 }
@@ -133,43 +133,44 @@ function deleteSelectedItems() {
     });
 
     $.ajax({
-        url: '/cart/deleteSelected',
-        type: 'POST',
-        traditional: true,
-        data: {itemIds: selectedItems},
+        url: '/cart/item',
+        type: 'DELETE',
+        contentType: 'application/json',
+        data: JSON.stringify({
+                itemIds: selectedItems
+        }),
         success: function (response) {
-            // 성공 처리
-            alert('선택된 상품이 삭제되었습니다.');
-            location.reload(); // 페이지 새로고침
+            alert(response.message);
+            location.reload();
             updateCartSummary();
         },
-        error: function (error) {
-            // 실패 처리
-            alert('삭제 중 오류가 발생했습니다.');
+        error: function (xhr, status, error) {
+            var errorMessage = JSON.parse(xhr.responseText).message;
+            alert(errorMessage);
         }
     });
 }
 
 function updateCartItemQuantity(itemId, quantity) {
     $.ajax({
-        url: '/cart/update',
-        type: 'POST',
-        data: {
+        url: '/cart/item',
+        type: 'PATCH',
+        contentType: 'application/json',
+        data: JSON.stringify({
             itemId: itemId,
             quantity: quantity
-        },
+        }),
         success: function (response) {
             var price = parseFloat($("tr[id='item-" + itemId + "']").find("td:eq(2)").text().replace('원', '').replace(',', '')); // 가격을 텍스트로 가져오는 대신에 숫자로 파싱하여 계산
             var newTotal = price * quantity;
             $("tr[id='item-" + itemId + "']").find(".item-total").text(newTotal + '원'); // 총 가격을 계산하여 텍스트로 설정
             updateCartSummary();
         },
-        error: function (error) {
-            alert('수량 업데이트 중 오류가 발생했습니다.');
+        error: function (xhr, status, error) {
+            var errorMessage = JSON.parse(xhr.responseText).message;
+            alert(errorMessage);
         }
     });
-
-
 
 // 페이지가 준비된 후 초기 한 번만 장바구니 요약을 업데이트합니다.
     $(document).ready(function () {
@@ -184,4 +185,3 @@ function updateCartItemQuantity(itemId, quantity) {
     });
     updateCartSummary();
 }
-

--- a/src/main/resources/templates/product/details.html
+++ b/src/main/resources/templates/product/details.html
@@ -113,9 +113,11 @@
                     <div class="buttons mt-4">
 
                         <form id="add-to-cart-form" action="/cart/add" method="post">
-                            <input type="number" name="quantity" value="1" class="form-control w-auto d-inline-block"/>
+                            <input type="number" name="quantity" value="1" id="quantity" class="form-control w-auto d-inline-block"/>
                             <input type="hidden" name="productID" th:value="${product.productID}"/>
-                            <button type="submit" class="btn btn-custom-success">장바구니에 추가</button>
+                            <button type="submit" class="btn btn-custom-success" id="add-to-cart"
+                                    th:data-product-id="${product.productID}">
+                                장바구니에 추가</button>
                             <button id="order-button" type="button" class="btn btn-custom-primary">바로 주문하기</button>
                         </form>
 
@@ -369,21 +371,26 @@
             });
         });
 
-        $("#add-to-cart-form").on('submit', function (e) {
-            e.preventDefault(); // 폼 기본 제출 막기
+        $("#add-to-cart").on('click', function (e) {
+            event.preventDefault(e);
 
-            var form = $(this);
-            var url = form.attr('action');
+            const productID = $(this).data("product-id");
+            const quantity = $("#quantity").val();
 
             $.ajax({
                 type: "POST",
-                url: url,
-                data: form.serialize(), // 폼 데이터를 직렬화
-                success: function (data) {
-                    alert("장바구니에 담겼습니다."); // 성공 알림
+                url: "/cart/item",
+                contentType: 'application/json',
+                data: JSON.stringify({
+                    productID: productID,
+                    quantity: quantity
+                }),
+                success: function (response) {
+                    alert(response.message);
                 },
                 error: function (xhr, status, error) {
-                    alert("장바구니 추가 에러 발생"); // 에러 알림
+                    var errorMessage = JSON.parse(xhr.responseText).message;
+                    alert(errorMessage);
                 }
             });
         });

--- a/src/main/resources/templates/users/myPage/active/favorites.html
+++ b/src/main/resources/templates/users/myPage/active/favorites.html
@@ -130,7 +130,7 @@
 
         $.ajax({
             type: "POST",
-            url: "/cart/add",
+            url: "/cart/item",
             data: {
                 productID: productID,
                 quantity: quantity


### PR DESCRIPTION
- 아이템 업데이트와 삭제를 위해 @PatchMapping과 @DeleteMapping 구현으로 의도 명확화 및 RESTfulness 향상.
- 데이터 전송 방식을 @RequestParam에서 @RequestBody로 전환하여, JSON 형태로 CRUD 작업 데이터 캡슐화.
- 장바구니 아이템 작업에 대해 일관된 URI 구조 적용으로 API 일관성 및 가독성 강화.
- 요청 결과를 클라이언트에게 명확히 알리기 위해 적절한 HTTP 상태 코드 및 메시지 사용 보장.